### PR TITLE
Wayland fixes and vsync

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -56,6 +56,24 @@ namespace Microsoft.Xna.Framework
         private bool _shouldExit;
         private bool _suppressDraw;
 
+        // If set to true, enables Wayland VSync on the SDL game platform.
+        public bool WaylandVsync
+        {
+            get
+            {
+                if (Platform is SdlGamePlatform sdlGamePlatform)
+                    return sdlGamePlatform.WaylandVsync;
+
+                return false;
+            }
+
+            set
+            {
+                if (Platform is SdlGamePlatform sdlGamePlatform)
+                    sdlGamePlatform.WaylandVsync = value;
+            }
+        }
+
         partial void PlatformConstruct();
 
         public Game()

--- a/MonoGame.Framework/Platform/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/Mouse.SDL.cs
@@ -24,17 +24,11 @@ namespace Microsoft.Xna.Framework.Input
         {
             int x, y;
             var winFlags = Sdl.Window.GetWindowFlags(window.Handle);
-            var state = Sdl.Mouse.GetGlobalState(out x, out y);
+            Sdl.Mouse.GetGlobalState(out x, out y);
 
             if ((winFlags & Sdl.Window.State.MouseFocus) != 0)
             {
-                // Window has mouse focus, position will be set from the motion event
-                window.MouseState.LeftButton = (state & Sdl.Mouse.Button.Left) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.MiddleButton = (state & Sdl.Mouse.Button.Middle) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.RightButton = (state & Sdl.Mouse.Button.Right) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.XButton1 = (state & Sdl.Mouse.Button.X1Mask) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.XButton2 = (state & Sdl.Mouse.Button.X2Mask) != 0 ? ButtonState.Pressed : ButtonState.Released;
-
+                // Window has mouse focus, position and button state will be set from the motion event
                 window.MouseState.HorizontalScrollWheelValue = ScrollX;
                 window.MouseState.ScrollWheelValue = ScrollY;
             }

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -643,13 +643,22 @@ internal static class Sdl
     public static class Mouse
     {
         [Flags]
-        public enum Button
+        public enum ButtonMask
         {
             Left = 1 << 0,
             Middle = 1 << 1,
             Right = 1 << 2,
             X1Mask = 1 << 3,
             X2Mask = 1 << 4
+        }
+
+        public enum Button
+        {
+            Left = 1,
+            Middle = 2,
+            Right = 3,
+            X1 = 4,
+            X2 = 5
         }
 
         public enum SystemCursor
@@ -735,11 +744,11 @@ internal static class Sdl
         public static d_sdl_freecursor FreeCursor = FuncLoader.LoadFunction<d_sdl_freecursor>(NativeLibrary, "SDL_FreeCursor");
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate Button d_sdl_getglobalmousestate(out int x, out int y);
+        public delegate ButtonMask d_sdl_getglobalmousestate(out int x, out int y);
         public static d_sdl_getglobalmousestate GetGlobalState = FuncLoader.LoadFunction<d_sdl_getglobalmousestate>(NativeLibrary, "SDL_GetGlobalMouseState");
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate Button d_sdl_getmousestate(out int x, out int y);
+        public delegate ButtonMask d_sdl_getmousestate(out int x, out int y);
         public static d_sdl_getmousestate GetState = FuncLoader.LoadFunction<d_sdl_getmousestate>(NativeLibrary, "SDL_GetMouseState");
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -152,6 +152,8 @@ internal static class Sdl
         [FieldOffset(0)]
         public Mouse.MotionEvent Motion;
         [FieldOffset(0)]
+        public Mouse.ButtonEvent Button;
+        [FieldOffset(0)]
         public Keyboard.TextEditingEvent Edit;
         [FieldOffset(0)]
         public Keyboard.TextInputEvent Text;
@@ -681,6 +683,21 @@ internal static class Sdl
             public int Y;
             public int Xrel;
             public int Yrel;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ButtonEvent
+        {
+            public EventType Type;
+            public uint Timestamp;
+            public uint WindowID;
+            public uint Which;
+            public byte Button;
+            public byte State;
+            public byte Clicks;
+            private byte _padding3;
+            public int X;
+            public int Y;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -380,7 +380,9 @@ internal static class Sdl
         {
             public Version version;
             public SysWMType subsystem;
-            public IntPtr window;
+            public IntPtr window; // Pointer to wl_display on Wayland
+
+            public IntPtr wl_surface; // Only on Wayland
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
@@ -26,6 +26,48 @@ namespace Microsoft.Xna.Framework
         private int _isExiting;
         private SdlGameWindow _view;
 
+        // If set to true, enables Wayland VSync.
+        public bool WaylandVsync { get; set; }
+
+        // The Wayland frame callback handle. When this is non-zero, we are waiting for the compositor to signal us when
+        // it is a good time to render a frame. This means, with Wayland V-Sync active, don't draw when this is non-zero.
+        private IntPtr _frameCallback;
+
+        // libdl stuff is needed to get a structure pointer from libwayland-client.so.
+        [DllImport("libdl.so.2")]
+        private static extern IntPtr dlopen(string path, int flags);
+        [DllImport("libdl.so.2")]
+        private static extern IntPtr dlsym(IntPtr handle, string symbol);
+        [DllImport("libdl.so.2")]
+        private static extern int dlclose(IntPtr handle);
+
+        // libwayland-client stuff for Wayland V-Sync.
+        [DllImport("wayland-client")]
+        private static extern IntPtr wl_proxy_marshal_constructor(IntPtr proxy, uint opcode, IntPtr _interface, IntPtr zero);
+        [DllImport("wayland-client")]
+        private static extern int wl_proxy_add_listener(IntPtr proxy, IntPtr implementation, IntPtr data);
+        [DllImport("wayland-client")]
+        private static extern void wl_proxy_destroy(IntPtr proxy);
+
+        private IntPtr _libwayland_client_handle;
+        private IntPtr _wl_surface;
+        private IntPtr _wl_callback_interface;
+
+        // The callback listener structure and its corresponding delegate.
+        [StructLayout(LayoutKind.Sequential)]
+        private struct WlCallbackListener
+        {
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate void d_done(IntPtr data, IntPtr wl_callback, uint callback_data);
+
+            public IntPtr Done;
+        };
+        private WlCallbackListener.d_done _frameDoneDelegate;
+        private WlCallbackListener _listener;
+
+        // A handle to pin the listener so the GC doesn't move it.
+        private GCHandle _listenerHandle;
+
         public SdlGamePlatform(Game game)
             : base(game)
         {
@@ -60,11 +102,49 @@ namespace Microsoft.Xna.Framework
 
             GamePad.InitDatabase();
             Window = _view = new SdlGameWindow(_game);
+
+            WaylandVsync = false;
+            _frameCallback = IntPtr.Zero;
+
+            _libwayland_client_handle = IntPtr.Zero;
+            _wl_surface = IntPtr.Zero;
+            _wl_callback_interface = IntPtr.Zero;
+
+            _frameDoneDelegate = FrameDone;
+            _listener = new WlCallbackListener
+            {
+                Done = Marshal.GetFunctionPointerForDelegate(_frameDoneDelegate)
+            };
+            // Prevent the GC from moving the listener around, as the C Wayland library will have a pointer to it.
+            _listenerHandle = GCHandle.Alloc(_listener, GCHandleType.Pinned);
         }
 
         public override void BeforeInitialize()
         {
             SdlRunLoop();
+
+            if (CurrentPlatform.OS == OS.Linux)
+            {
+                // Get the WM type.
+                Sdl.GetVersion(out var version);
+                var sys = new Sdl.Window.SDL_SysWMinfo
+                {
+                    version = version
+                };
+
+                if (Sdl.Window.GetWindowWMInfo(Window.Handle, ref sys))
+                {
+                    if (sys.subsystem == Sdl.Window.SysWMType.Wayland)
+                    {
+                        // Get pointer to wl_surface and the wl_callback_interface to be able to request a frame callback.
+                        _wl_surface = sys.wl_surface;
+
+                        _libwayland_client_handle = dlopen("libwayland-client.so", 1);
+                        if (_libwayland_client_handle != IntPtr.Zero)
+                            _wl_callback_interface = dlsym(_libwayland_client_handle, "wl_callback_interface");
+                    }
+                }
+            }
 
             base.BeforeInitialize();
         }
@@ -89,6 +169,19 @@ namespace Microsoft.Xna.Framework
             while (true)
             {
                 SdlRunLoop();
+
+                // If frame_callback is non-zero, we're waiting for the Wayland compositor to signal us when it's a good
+                // time to draw a frame. With Wayland V-Sync active, suppress drawing until we receive that signal.
+                if (WaylandVsync && _frameCallback != IntPtr.Zero)
+                    Game.SuppressDraw();
+
+                // If we're on Wayland and haven't requested a frame callback for the next refresh, do so.
+                if (_wl_callback_interface != IntPtr.Zero && _frameCallback == IntPtr.Zero)
+                {
+                    _frameCallback = wl_proxy_marshal_constructor(_wl_surface, 3, _wl_callback_interface, IntPtr.Zero);
+                    wl_proxy_add_listener(_frameCallback, _listenerHandle.AddrOfPinnedObject(), IntPtr.Zero);
+                }
+
                 Game.Tick();
                 Threading.Run();
                 GraphicsDevice.DisposeContexts();
@@ -310,6 +403,19 @@ namespace Microsoft.Xna.Framework
             Console.WriteLine(message);
         }
 
+        private void FrameDone(IntPtr data, IntPtr wl_callback, uint callback_data)
+        {
+            // Wayland callbacks are (most likely) dispatched within SDL.PollEvent within SdlRunLoop, which happens
+            // on the same thread as everything else, so no synchronization is necessary.
+
+            // Destroy the callback (necessary).
+            // wl_callback should be the same as frame_callback as we only register a single one.
+            wl_proxy_destroy(wl_callback);
+
+            // Set our variable back to zero so we know the callback has fired.
+            _frameCallback = IntPtr.Zero;
+        }
+
         public override void Present()
         {
             if (Game.GraphicsDevice != null)
@@ -318,6 +424,11 @@ namespace Microsoft.Xna.Framework
 
         protected override void Dispose(bool disposing)
         {
+            if (_frameCallback != IntPtr.Zero)
+                wl_proxy_destroy(_frameCallback);
+            if (_libwayland_client_handle != IntPtr.Zero)
+                dlclose(_libwayland_client_handle);
+
             if (_view != null)
             {
                 _view.Dispose();

--- a/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
@@ -137,6 +137,34 @@ namespace Microsoft.Xna.Framework
                     var key = KeyboardUtil.ToXna(ev.Key.Keysym.Sym);
                     _keys.Remove(key);
                 }
+                else if (ev.Type == Sdl.EventType.MouseButtonDown || ev.Type == Sdl.EventType.MouseButtonup)
+                {
+                    switch ((Sdl.Mouse.Button) ev.Button.Button)
+                    {
+                        case Sdl.Mouse.Button.Left:
+                            Window.MouseState.LeftButton = ev.Button.State != 0 ? ButtonState.Pressed : ButtonState.Released;
+                            break;
+
+                        case Sdl.Mouse.Button.Right:
+                            Window.MouseState.RightButton = ev.Button.State != 0 ? ButtonState.Pressed : ButtonState.Released;
+                            break;
+
+                        case Sdl.Mouse.Button.Middle:
+                            Window.MouseState.MiddleButton = ev.Button.State != 0 ? ButtonState.Pressed : ButtonState.Released;
+                            break;
+
+                        case Sdl.Mouse.Button.X1:
+                            Window.MouseState.XButton1 = ev.Button.State != 0 ? ButtonState.Pressed : ButtonState.Released;
+                            break;
+
+                        case Sdl.Mouse.Button.X2:
+                            Window.MouseState.XButton2 = ev.Button.State != 0 ? ButtonState.Pressed : ButtonState.Released;
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
                 else if (ev.Type == Sdl.EventType.TextInput)
                 {
                     if (_view.IsTextInputHandled)


### PR DESCRIPTION
This changes the SDL mouse handling to use events to work on Wayland and adds the Wayland VSync option. Check commit messages for more.