### PR TITLE
Convert dropped file path to a local path

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -307,6 +307,10 @@ namespace Microsoft.Xna.Framework
 
         public void CallFileDrop(string filepath)
         {
+            // If e is a file:// URI (for example, on Wayland), it needs to be converted to a local path. If it's
+            // already a local path, this function leaves it as is.
+            filepath = new Uri(filepath).LocalPath;
+
             OnFileDropped(this, filepath);
         }
 


### PR DESCRIPTION
On Wayland it's a file:// URI that needs to be converted. If the path is already a local path, this conversion leaves it as is.

cc https://github.com/Quaver/Quaver/issues/944