### PR TITLE
Fix NVorbis submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/Mono-Game/MonoGame.Dependencies.git
 [submodule "ThirdParty/NVorbis"]
 	path = ThirdParty/NVorbis
-url=https://github.com/MrHelmut/NVorbis.git
+url=https://github.com/NVorbis/NVorbis.git
 [submodule "gamecontrollerdb"]
 	path = gamecontrollerdb
 	url = https://github.com/gabomdq/gamecontrollerdb


### PR DESCRIPTION
The old repo was deleted breaking quaver clones.